### PR TITLE
[css-align-3] fix figure description (editorial)

### DIFF
--- a/css-align-3/Overview.bs
+++ b/css-align-3/Overview.bs
@@ -806,9 +806,9 @@ Overflow Alignment: the ''safe'' and ''unsafe'' keywords and scroll safety limit
 				</div>
 			</div>
 			<figcaption>
-				The items in the figure on the right all strictly centered,
+				The items in the figure on the left are all strictly centered,
 				even if the one that is too long to fit overflows on both sides,
-				while those in the figure on the left are centered unless they overflow,
+				while those in the figure on the right are centered unless they overflow,
 				in which case all the overflow goes off the end edge.
 				If the container was placed
 				against the left edge of the page,


### PR DESCRIPTION
"Left" and "right" figure references were swapped for some reason, this edit fixes them